### PR TITLE
修复v3.5.x 支持http 优雅关闭后，v3.6.x 中新组件taskserver不支持的问题 

### DIFF
--- a/src/scene_server/task_server/app/server.go
+++ b/src/scene_server/task_server/app/server.go
@@ -35,7 +35,7 @@ import (
 	"github.com/emicklei/go-restful"
 )
 
-func Run(ctx context.Context, op *options.ServerOption) error {
+func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
 	svrInfo, err := newServerInfo(op)
 	if err != nil {
 		blog.Errorf("wrap server info failed, err: %v", err)
@@ -88,7 +88,7 @@ func Run(ctx context.Context, op *options.ServerOption) error {
 	taskSrv.Core = engine
 	taskSrv.Service = service
 
-	if err := backbone.StartServer(ctx, engine, service.WebService(), true); err != nil {
+	if err := backbone.StartServer(ctx, cancel, engine, service.WebService(), true); err != nil {
 		blog.Errorf("start backbone failed, err: %+v", err)
 		return err
 	}

--- a/src/scene_server/task_server/task.go
+++ b/src/scene_server/task_server/task.go
@@ -43,8 +43,8 @@ func main() {
 	if err := common.SavePid(); err != nil {
 		blog.Errorf("fail to save pid: err:%s", err.Error())
 	}
-
-	if err := app.Run(context.Background(), op); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := app.Run(ctx, cancel, op); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		blog.Errorf("process stopped by %v", err)
 		blog.CloseLogs()


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 修复v3.5.x 支持http 优雅关闭后，v3.6.x 中新组件taskserver不支持的问题 
